### PR TITLE
feat: JWT + Spring Security 認証実装

### DIFF
--- a/backend/src/main/java/com/gitquest/backend/config/SecurityConfig.java
+++ b/backend/src/main/java/com/gitquest/backend/config/SecurityConfig.java
@@ -1,0 +1,65 @@
+package com.gitquest.backend.config;
+
+import com.gitquest.backend.security.JwtAuthenticationFilter;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+import java.util.List;
+
+@Configuration
+@EnableWebSecurity
+public class SecurityConfig {
+
+    private final JwtAuthenticationFilter jwtAuthenticationFilter;
+
+    @Value("${app.cors.allowed-origins}")
+    private String allowedOrigins;
+
+    public SecurityConfig(JwtAuthenticationFilter jwtAuthenticationFilter) {
+        this.jwtAuthenticationFilter = jwtAuthenticationFilter;
+    }
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        return http
+                .csrf(AbstractHttpConfigurer::disable)
+                .cors(cors -> cors.configurationSource(corsConfigurationSource()))
+                .sessionManagement(s -> s.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers("/api/auth/**").permitAll()
+                        .anyRequest().authenticated()
+                )
+                .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
+                .build();
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+    @Bean
+    public CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration config = new CorsConfiguration();
+        config.setAllowedOrigins(List.of(allowedOrigins.split(",")));
+        config.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "OPTIONS"));
+        config.setAllowedHeaders(List.of("*"));
+        config.setAllowCredentials(true);
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", config);
+        return source;
+    }
+}

--- a/backend/src/main/java/com/gitquest/backend/controller/AuthController.java
+++ b/backend/src/main/java/com/gitquest/backend/controller/AuthController.java
@@ -1,0 +1,30 @@
+package com.gitquest.backend.controller;
+
+import com.gitquest.backend.dto.auth.AuthResponse;
+import com.gitquest.backend.dto.auth.LoginRequest;
+import com.gitquest.backend.dto.auth.RegisterRequest;
+import com.gitquest.backend.service.AuthService;
+import jakarta.validation.Valid;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/auth")
+public class AuthController {
+
+    private final AuthService authService;
+
+    public AuthController(AuthService authService) {
+        this.authService = authService;
+    }
+
+    @PostMapping("/register")
+    public ResponseEntity<AuthResponse> register(@Valid @RequestBody RegisterRequest request) {
+        return ResponseEntity.ok(authService.register(request));
+    }
+
+    @PostMapping("/login")
+    public ResponseEntity<AuthResponse> login(@Valid @RequestBody LoginRequest request) {
+        return ResponseEntity.ok(authService.login(request));
+    }
+}

--- a/backend/src/main/java/com/gitquest/backend/dto/auth/AuthResponse.java
+++ b/backend/src/main/java/com/gitquest/backend/dto/auth/AuthResponse.java
@@ -1,0 +1,15 @@
+package com.gitquest.backend.dto.auth;
+
+import java.util.UUID;
+
+public record AuthResponse(
+        String accessToken,
+        String tokenType,
+        UUID userId,
+        String username,
+        String email
+) {
+    public static AuthResponse of(String token, UUID userId, String username, String email) {
+        return new AuthResponse(token, "Bearer", userId, username, email);
+    }
+}

--- a/backend/src/main/java/com/gitquest/backend/dto/auth/LoginRequest.java
+++ b/backend/src/main/java/com/gitquest/backend/dto/auth/LoginRequest.java
@@ -1,0 +1,8 @@
+package com.gitquest.backend.dto.auth;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record LoginRequest(
+        @NotBlank String email,
+        @NotBlank String password
+) {}

--- a/backend/src/main/java/com/gitquest/backend/dto/auth/RegisterRequest.java
+++ b/backend/src/main/java/com/gitquest/backend/dto/auth/RegisterRequest.java
@@ -1,0 +1,16 @@
+package com.gitquest.backend.dto.auth;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record RegisterRequest(
+        @NotBlank @Size(min = 3, max = 50)
+        String username,
+
+        @NotBlank @Email
+        String email,
+
+        @NotBlank @Size(min = 8, max = 100)
+        String password
+) {}

--- a/backend/src/main/java/com/gitquest/backend/entity/User.java
+++ b/backend/src/main/java/com/gitquest/backend/entity/User.java
@@ -1,0 +1,50 @@
+package com.gitquest.backend.entity;
+
+import jakarta.persistence.*;
+import java.time.OffsetDateTime;
+import java.util.UUID;
+
+@Entity
+@Table(name = "users")
+public class User {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    @Column(nullable = false, unique = true, length = 50)
+    private String username;
+
+    @Column(nullable = false, unique = true, length = 255)
+    private String email;
+
+    @Column(name = "password_hash", nullable = false, length = 255)
+    private String passwordHash;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private OffsetDateTime createdAt;
+
+    @Column(name = "updated_at", nullable = false)
+    private OffsetDateTime updatedAt;
+
+    @PrePersist
+    protected void onCreate() {
+        createdAt = OffsetDateTime.now();
+        updatedAt = OffsetDateTime.now();
+    }
+
+    @PreUpdate
+    protected void onUpdate() {
+        updatedAt = OffsetDateTime.now();
+    }
+
+    public UUID getId() { return id; }
+    public String getUsername() { return username; }
+    public void setUsername(String username) { this.username = username; }
+    public String getEmail() { return email; }
+    public void setEmail(String email) { this.email = email; }
+    public String getPasswordHash() { return passwordHash; }
+    public void setPasswordHash(String passwordHash) { this.passwordHash = passwordHash; }
+    public OffsetDateTime getCreatedAt() { return createdAt; }
+    public OffsetDateTime getUpdatedAt() { return updatedAt; }
+}

--- a/backend/src/main/java/com/gitquest/backend/repository/UserRepository.java
+++ b/backend/src/main/java/com/gitquest/backend/repository/UserRepository.java
@@ -1,0 +1,13 @@
+package com.gitquest.backend.repository;
+
+import com.gitquest.backend.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+import java.util.UUID;
+
+public interface UserRepository extends JpaRepository<User, UUID> {
+    Optional<User> findByEmail(String email);
+    boolean existsByEmail(String email);
+    boolean existsByUsername(String username);
+}

--- a/backend/src/main/java/com/gitquest/backend/security/JwtAuthenticationFilter.java
+++ b/backend/src/main/java/com/gitquest/backend/security/JwtAuthenticationFilter.java
@@ -1,0 +1,63 @@
+package com.gitquest.backend.security;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+// リクエストごとに1回だけ実行される JWT 検証フィルター
+@Component
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private final JwtUtil jwtUtil;
+    private final UserDetailsServiceImpl userDetailsService;
+
+    public JwtAuthenticationFilter(JwtUtil jwtUtil, UserDetailsServiceImpl userDetailsService) {
+        this.jwtUtil = jwtUtil;
+        this.userDetailsService = userDetailsService;
+    }
+
+    @Override
+    protected void doFilterInternal(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            FilterChain filterChain
+    ) throws ServletException, IOException {
+
+        // Authorization ヘッダーから "Bearer {token}" を取り出す
+        String authHeader = request.getHeader("Authorization");
+        if (authHeader == null || !authHeader.startsWith("Bearer ")) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        String token = authHeader.substring(7);
+
+        if (!jwtUtil.isTokenValid(token)) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        String email = jwtUtil.extractEmail(token);
+
+        if (email != null && SecurityContextHolder.getContext().getAuthentication() == null) {
+            UserDetails userDetails = userDetailsService.loadUserByUsername(email);
+            UsernamePasswordAuthenticationToken authentication =
+                    new UsernamePasswordAuthenticationToken(
+                            userDetails, null, userDetails.getAuthorities()
+                    );
+            authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+        }
+
+        filterChain.doFilter(request, response);
+    }
+}

--- a/backend/src/main/java/com/gitquest/backend/security/JwtUtil.java
+++ b/backend/src/main/java/com/gitquest/backend/security/JwtUtil.java
@@ -1,0 +1,55 @@
+package com.gitquest.backend.security;
+
+import io.jsonwebtoken.*;
+import io.jsonwebtoken.security.Keys;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.SecretKey;
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
+
+@Component
+public class JwtUtil {
+
+    private final SecretKey secretKey;
+    private final long expirationMs;
+
+    public JwtUtil(
+            @Value("${app.jwt.secret}") String secret,
+            @Value("${app.jwt.expiration-ms}") long expirationMs
+    ) {
+        this.secretKey = Keys.hmacShaKeyFor(secret.getBytes(StandardCharsets.UTF_8));
+        this.expirationMs = expirationMs;
+    }
+
+    public String generateToken(String email) {
+        return Jwts.builder()
+                .subject(email)
+                .issuedAt(new Date())
+                .expiration(new Date(System.currentTimeMillis() + expirationMs))
+                .signWith(secretKey)
+                .compact();
+    }
+
+    public String extractEmail(String token) {
+        return parseClaims(token).getSubject();
+    }
+
+    public boolean isTokenValid(String token) {
+        try {
+            parseClaims(token);
+            return true;
+        } catch (JwtException | IllegalArgumentException e) {
+            return false;
+        }
+    }
+
+    private Claims parseClaims(String token) {
+        return Jwts.parser()
+                .verifyWith(secretKey)
+                .build()
+                .parseSignedClaims(token)
+                .getPayload();
+    }
+}

--- a/backend/src/main/java/com/gitquest/backend/security/UserDetailsServiceImpl.java
+++ b/backend/src/main/java/com/gitquest/backend/security/UserDetailsServiceImpl.java
@@ -1,0 +1,25 @@
+package com.gitquest.backend.security;
+
+import com.gitquest.backend.repository.UserRepository;
+import org.springframework.security.core.userdetails.*;
+import org.springframework.stereotype.Service;
+
+@Service
+public class UserDetailsServiceImpl implements UserDetailsService {
+
+    private final UserRepository userRepository;
+
+    public UserDetailsServiceImpl(UserRepository userRepository) {
+        this.userRepository = userRepository;
+    }
+
+    @Override
+    public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
+        return userRepository.findByEmail(email)
+                .map(user -> User.withUsername(user.getEmail())
+                        .password(user.getPasswordHash())
+                        .authorities("ROLE_USER")
+                        .build())
+                .orElseThrow(() -> new UsernameNotFoundException("User not found: " + email));
+    }
+}

--- a/backend/src/main/java/com/gitquest/backend/service/AuthService.java
+++ b/backend/src/main/java/com/gitquest/backend/service/AuthService.java
@@ -1,0 +1,57 @@
+package com.gitquest.backend.service;
+
+import com.gitquest.backend.dto.auth.AuthResponse;
+import com.gitquest.backend.dto.auth.LoginRequest;
+import com.gitquest.backend.dto.auth.RegisterRequest;
+import com.gitquest.backend.entity.User;
+import com.gitquest.backend.repository.UserRepository;
+import com.gitquest.backend.security.JwtUtil;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class AuthService {
+
+    private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+    private final JwtUtil jwtUtil;
+
+    public AuthService(UserRepository userRepository, PasswordEncoder passwordEncoder, JwtUtil jwtUtil) {
+        this.userRepository = userRepository;
+        this.passwordEncoder = passwordEncoder;
+        this.jwtUtil = jwtUtil;
+    }
+
+    @Transactional
+    public AuthResponse register(RegisterRequest request) {
+        if (userRepository.existsByEmail(request.email())) {
+            throw new IllegalArgumentException("このメールアドレスはすでに使用されています");
+        }
+        if (userRepository.existsByUsername(request.username())) {
+            throw new IllegalArgumentException("このユーザー名はすでに使用されています");
+        }
+
+        User user = new User();
+        user.setUsername(request.username());
+        user.setEmail(request.email());
+        user.setPasswordHash(passwordEncoder.encode(request.password()));
+
+        User saved = userRepository.save(user);
+        String token = jwtUtil.generateToken(saved.getEmail());
+        return AuthResponse.of(token, saved.getId(), saved.getUsername(), saved.getEmail());
+    }
+
+    public AuthResponse login(LoginRequest request) {
+        User user = userRepository.findByEmail(request.email())
+                .orElseThrow(() -> new BadCredentialsException("メールアドレスまたはパスワードが正しくありません"));
+
+        if (!passwordEncoder.matches(request.password(), user.getPasswordHash())) {
+            throw new BadCredentialsException("メールアドレスまたはパスワードが正しくありません");
+        }
+
+        String token = jwtUtil.generateToken(user.getEmail());
+        return AuthResponse.of(token, user.getId(), user.getUsername(), user.getEmail());
+    }
+}

--- a/docs/learning/04_jwt_spring_security.md
+++ b/docs/learning/04_jwt_spring_security.md
@@ -1,0 +1,229 @@
+# JWT 認証と Spring Security 解説
+
+## 認証とは何か
+
+アプリを使うとき「あなたは誰ですか？」を確認する仕組みです。
+
+認証がないと:
+- 誰でも誰の進捗でも見られる
+- 誰でも誰の進捗を消せる
+
+ログインした人だけが自分のデータにアクセスできるように守ります。
+
+---
+
+## セッション認証 vs JWT 認証
+
+### 昔ながらのセッション認証
+
+```
+1. ユーザーがログイン
+2. サーバーが「セッション情報」をサーバー内のメモリに保存
+3. ブラウザにセッション ID をクッキーで渡す
+4. 次のリクエストでクッキーを送る → サーバーで照合
+```
+
+問題: サーバーにデータを保存するので、サーバーが複数台になると厄介。
+
+### JWT 認証（今回使う方法）
+
+```
+1. ユーザーがログイン
+2. サーバーが JWT トークンを生成してクライアントに渡す
+3. クライアント（ブラウザ）がトークンを保存
+4. 次のリクエストでトークンを Authorization ヘッダーにつける
+5. サーバーはトークンを「検証」するだけ（何も保存しない）
+```
+
+メリット: サーバーに状態を保存しない（Stateless）
+
+---
+
+## JWT の構造
+
+JWT（JSON Web Token）は3つのパーツが `.` でつながっています。
+
+```
+eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJrYXp1a2lAZXhhbXBsZS5jb20ifQ.abc123
+^---ヘッダー---^      ^--------ペイロード--------^              ^署名^
+```
+
+Base64 デコードすると中身が見えます:
+
+ペイロード（本体）:
+```json
+{
+  "sub": "kazuki@example.com",  // 誰のトークンか
+  "iat": 1776402935,             // 発行時刻
+  "exp": 1776489335              // 有効期限
+}
+```
+
+署名: サーバーだけが知る秘密鍵で作ったハッシュ値。
+改ざんされると署名が合わなくなるのでバレます。
+
+重要: JWT の中身は誰でも見られます（暗号化ではない）。
+パスワードなど秘密情報は絶対に入れてはいけません。
+
+---
+
+## 実装ファイルの役割
+
+### JwtUtil.java — トークンの生成と検証
+
+```java
+// トークンを生成する
+public String generateToken(String email) {
+    return Jwts.builder()
+            .subject(email)       // 誰のトークンか
+            .issuedAt(new Date()) // 発行時刻
+            .expiration(...)      // 有効期限（24時間後）
+            .signWith(secretKey)  // 秘密鍵で署名
+            .compact();           // 文字列に変換
+}
+```
+
+### JwtAuthenticationFilter.java — 全リクエストをチェック
+
+全てのリクエストに割り込んで JWT を検証します。
+
+```
+リクエスト受信
+    ↓
+Authorization ヘッダーを確認
+    ↓ "Bearer eyJhbG..." の形式かチェック
+トークンを取り出して検証
+    ↓ 有効なら
+Spring Security のコンテキストに「誰からのリクエストか」をセット
+    ↓
+Controller へ（通常の処理）
+```
+
+### SecurityConfig.java — どのURLを守るか設定
+
+```java
+.authorizeHttpRequests(auth -> auth
+    .requestMatchers("/api/auth/**").permitAll()  // ログイン・登録は誰でもOK
+    .anyRequest().authenticated()                  // それ以外はログイン必須
+)
+```
+
+`/api/auth/**` を認証不要にしないと、そもそもログインできなくなってしまいます。
+
+### AuthService.java — ログイン・登録のロジック
+
+```java
+// 登録処理の流れ
+public AuthResponse register(RegisterRequest request) {
+    // 1. メールアドレスの重複チェック
+    if (userRepository.existsByEmail(request.email())) {
+        throw new IllegalArgumentException("すでに使用されています");
+    }
+    // 2. パスワードをハッシュ化して保存
+    user.setPasswordHash(passwordEncoder.encode(request.password()));
+    // 3. JWT トークンを生成して返す
+    String token = jwtUtil.generateToken(saved.getEmail());
+    return AuthResponse.of(token, ...);
+}
+```
+
+---
+
+## bcrypt とは
+
+パスワードを安全に保存するためのハッシュ関数です。
+
+```
+パスワード: "password123"
+      ↓ bcrypt でハッシュ化
+保存値: "$2b$10$EixZaYVK1fsbw1ZfbX3OXe..."
+```
+
+「ハッシュ化」= 元に戻せない変換。
+DB が流出してもハッシュから元のパスワードはわかりません。
+
+ログイン時の照合:
+```java
+// ハッシュ化して比較するので元のパスワードは不要
+passwordEncoder.matches("password123", storedHash) // true or false
+```
+
+---
+
+## record とは（Java 16+）
+
+データを運ぶだけのクラスを短く書ける構文です。
+
+```java
+// 通常のクラス（長い）
+public class LoginRequest {
+    private final String email;
+    private final String password;
+    public LoginRequest(String email, String password) { ... }
+    public String getEmail() { return email; }
+    public String getPassword() { return password; }
+}
+
+// record（シンプル）
+public record LoginRequest(String email, String password) {}
+// コンストラクタ・getter が自動生成される
+```
+
+DTO（データを運ぶだけのクラス）に最適な書き方です。
+
+---
+
+## CORS とは
+
+「別のドメインからのリクエストをブロックする」ブラウザの機能です。
+
+```
+フロントエンド: http://localhost:3000  (Nuxt.js)
+バックエンド:   http://localhost:8080  (Spring Boot)
+```
+
+ポート番号が違うので「別オリジン」 = CORS の制限が発生します。
+Spring Boot 側で「localhost:3000 は OK」と設定することで解決します。
+
+---
+
+## @アノテーション とは
+
+Java のアノテーション = クラスやメソッドへの「ラベル」です。
+
+```java
+@Entity           // このクラスはDBのテーブルと対応している
+@Table(name = "users")  // テーブル名は "users"
+public class User {
+
+    @Id           // これが主キー
+    @Column(nullable = false)  // NOT NULL 制約
+    private String email;
+}
+```
+
+`@アノテーション` を書くだけで Spring Boot が自動で設定してくれます。
+自分でゼロから書く必要がなく、宣言するだけで動くのが Spring Boot の強みです。
+
+---
+
+## API の確認方法
+
+```bash
+# ユーザー登録
+curl -X POST http://localhost:8080/api/auth/register \
+  -H "Content-Type: application/json" \
+  -d '{"username":"kazuki","email":"kazuki@example.com","password":"password123"}'
+
+# ログイン → accessToken が返ってくる
+curl -X POST http://localhost:8080/api/auth/login \
+  -H "Content-Type: application/json" \
+  -d '{"email":"kazuki@example.com","password":"password123"}'
+
+# 認証が必要な API（トークンをつける）
+curl http://localhost:8080/api/missions \
+  -H "Authorization: Bearer eyJhbGci..."
+```
+
+`curl` = ターミナルから HTTP リクエストを送るコマンド。
+`-H` = ヘッダーを指定。`-d` = 送るデータ（JSON）。


### PR DESCRIPTION
## 概要
- ユーザー登録・ログイン API（`/api/auth/register`, `/api/auth/login`）
- JWT トークン発行・検証（JwtUtil）
- 全リクエストを検証する JWT フィルター（JwtAuthenticationFilter）
- Spring Security 設定・CORS 設定（SecurityConfig）
- bcrypt パスワードハッシュ化

## 動作確認
- [x] `POST /api/auth/register` → JWT トークン返却
- [x] `POST /api/auth/login` → JWT トークン返却

Closes #5