### PR TITLE
feat: ミッション一覧・詳細 API 実装

### DIFF
--- a/backend/src/main/java/com/gitquest/backend/controller/MissionController.java
+++ b/backend/src/main/java/com/gitquest/backend/controller/MissionController.java
@@ -1,0 +1,33 @@
+package com.gitquest.backend.controller;
+
+import com.gitquest.backend.dto.mission.MissionResponse;
+import com.gitquest.backend.service.MissionService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/api/missions")
+public class MissionController {
+
+    private final MissionService missionService;
+
+    public MissionController(MissionService missionService) {
+        this.missionService = missionService;
+    }
+
+    // GET /api/missions → レベルごとにグルーピングされたミッション一覧
+    @GetMapping
+    public ResponseEntity<Map<Integer, List<MissionResponse>>> getAll() {
+        return ResponseEntity.ok(missionService.getAllGroupedByLevel());
+    }
+
+    // GET /api/missions/{id} → ミッション詳細（ステップ付き）
+    @GetMapping("/{id}")
+    public ResponseEntity<MissionResponse> getById(@PathVariable UUID id) {
+        return ResponseEntity.ok(missionService.getById(id));
+    }
+}

--- a/backend/src/main/java/com/gitquest/backend/dto/mission/MissionResponse.java
+++ b/backend/src/main/java/com/gitquest/backend/dto/mission/MissionResponse.java
@@ -1,0 +1,28 @@
+package com.gitquest.backend.dto.mission;
+
+import com.gitquest.backend.entity.Mission;
+
+import java.util.List;
+import java.util.UUID;
+
+public record MissionResponse(
+        UUID id,
+        int level,
+        int orderIndex,
+        String title,
+        String description,
+        String hint,
+        List<MissionStepResponse> steps
+) {
+    public static MissionResponse from(Mission mission) {
+        return new MissionResponse(
+                mission.getId(),
+                mission.getLevel(),
+                mission.getOrderIndex(),
+                mission.getTitle(),
+                mission.getDescription(),
+                mission.getHint(),
+                mission.getSteps().stream().map(MissionStepResponse::from).toList()
+        );
+    }
+}

--- a/backend/src/main/java/com/gitquest/backend/dto/mission/MissionStepResponse.java
+++ b/backend/src/main/java/com/gitquest/backend/dto/mission/MissionStepResponse.java
@@ -1,0 +1,21 @@
+package com.gitquest.backend.dto.mission;
+
+import com.gitquest.backend.entity.MissionStep;
+
+import java.util.UUID;
+
+public record MissionStepResponse(
+        UUID id,
+        int orderIndex,
+        String description,
+        String expectedCommand
+) {
+    public static MissionStepResponse from(MissionStep step) {
+        return new MissionStepResponse(
+                step.getId(),
+                step.getOrderIndex(),
+                step.getDescription(),
+                step.getExpectedCommand()
+        );
+    }
+}

--- a/backend/src/main/java/com/gitquest/backend/entity/Mission.java
+++ b/backend/src/main/java/com/gitquest/backend/entity/Mission.java
@@ -1,0 +1,51 @@
+package com.gitquest.backend.entity;
+
+import jakarta.persistence.*;
+import java.time.OffsetDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+@Entity
+@Table(name = "missions")
+public class Mission {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    @Column(nullable = false)
+    private int level;
+
+    @Column(name = "order_index", nullable = false)
+    private int orderIndex;
+
+    @Column(nullable = false, length = 100)
+    private String title;
+
+    @Column(nullable = false, columnDefinition = "TEXT")
+    private String description;
+
+    @Column(columnDefinition = "TEXT")
+    private String hint;
+
+    // ミッションのステップ一覧（順番通りに取得）
+    @OneToMany(mappedBy = "mission", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+    @OrderBy("orderIndex ASC")
+    private List<MissionStep> steps = new ArrayList<>();
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private OffsetDateTime createdAt;
+
+    @PrePersist
+    protected void onCreate() { createdAt = OffsetDateTime.now(); }
+
+    public UUID getId() { return id; }
+    public int getLevel() { return level; }
+    public int getOrderIndex() { return orderIndex; }
+    public String getTitle() { return title; }
+    public String getDescription() { return description; }
+    public String getHint() { return hint; }
+    public List<MissionStep> getSteps() { return steps; }
+    public OffsetDateTime getCreatedAt() { return createdAt; }
+}

--- a/backend/src/main/java/com/gitquest/backend/entity/MissionStep.java
+++ b/backend/src/main/java/com/gitquest/backend/entity/MissionStep.java
@@ -1,0 +1,32 @@
+package com.gitquest.backend.entity;
+
+import jakarta.persistence.*;
+import java.util.UUID;
+
+@Entity
+@Table(name = "mission_steps")
+public class MissionStep {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "mission_id", nullable = false)
+    private Mission mission;
+
+    @Column(name = "order_index", nullable = false)
+    private int orderIndex;
+
+    @Column(nullable = false, length = 200)
+    private String description;
+
+    @Column(name = "expected_command", nullable = false, length = 200)
+    private String expectedCommand;
+
+    public UUID getId() { return id; }
+    public Mission getMission() { return mission; }
+    public int getOrderIndex() { return orderIndex; }
+    public String getDescription() { return description; }
+    public String getExpectedCommand() { return expectedCommand; }
+}

--- a/backend/src/main/java/com/gitquest/backend/repository/MissionRepository.java
+++ b/backend/src/main/java/com/gitquest/backend/repository/MissionRepository.java
@@ -1,0 +1,12 @@
+package com.gitquest.backend.repository;
+
+import com.gitquest.backend.entity.Mission;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.UUID;
+
+public interface MissionRepository extends JpaRepository<Mission, UUID> {
+    List<Mission> findByLevelOrderByOrderIndexAsc(int level);
+    List<Mission> findAllByOrderByLevelAscOrderIndexAsc();
+}

--- a/backend/src/main/java/com/gitquest/backend/service/MissionService.java
+++ b/backend/src/main/java/com/gitquest/backend/service/MissionService.java
@@ -1,0 +1,38 @@
+package com.gitquest.backend.service;
+
+import com.gitquest.backend.dto.mission.MissionResponse;
+import com.gitquest.backend.repository.MissionRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+@Service
+public class MissionService {
+
+    private final MissionRepository missionRepository;
+
+    public MissionService(MissionRepository missionRepository) {
+        this.missionRepository = missionRepository;
+    }
+
+    // 全ミッションをレベルごとにグルーピングして返す
+    @Transactional(readOnly = true)
+    public Map<Integer, List<MissionResponse>> getAllGroupedByLevel() {
+        return missionRepository.findAllByOrderByLevelAscOrderIndexAsc()
+                .stream()
+                .map(MissionResponse::from)
+                .collect(Collectors.groupingBy(MissionResponse::level));
+    }
+
+    // 指定 ID のミッション詳細（ステップ付き）を返す
+    @Transactional(readOnly = true)
+    public MissionResponse getById(UUID id) {
+        return missionRepository.findById(id)
+                .map(MissionResponse::from)
+                .orElseThrow(() -> new IllegalArgumentException("ミッションが見つかりません"));
+    }
+}


### PR DESCRIPTION
## 概要
- Mission / MissionStep Entity・Repository 実装
- GET /api/missions → レベル別グルーピング一覧
- GET /api/missions/{id} → ステップ付き詳細

## 動作確認
- [x] GET /api/missions → レベル1〜3のミッション取得確認

Closes #10