### PR TITLE
feat: ユーザー進捗 API 実装 (#11)

### DIFF
--- a/backend/src/main/java/com/gitquest/backend/controller/ProgressController.java
+++ b/backend/src/main/java/com/gitquest/backend/controller/ProgressController.java
@@ -1,0 +1,38 @@
+package com.gitquest.backend.controller;
+
+import com.gitquest.backend.dto.progress.ProgressResponse;
+import com.gitquest.backend.service.ProgressService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/api/progress")
+public class ProgressController {
+
+    private final ProgressService progressService;
+
+    public ProgressController(ProgressService progressService) {
+        this.progressService = progressService;
+    }
+
+    // GET /api/progress → 自分の進捗一覧
+    @GetMapping
+    public ResponseEntity<List<ProgressResponse>> getMyProgress() {
+        return ResponseEntity.ok(progressService.getMyProgress());
+    }
+
+    // POST /api/progress/{missionId}/start → ミッション開始
+    @PostMapping("/{missionId}/start")
+    public ResponseEntity<ProgressResponse> start(@PathVariable UUID missionId) {
+        return ResponseEntity.ok(progressService.start(missionId));
+    }
+
+    // POST /api/progress/{missionId}/complete → ミッション完了
+    @PostMapping("/{missionId}/complete")
+    public ResponseEntity<ProgressResponse> complete(@PathVariable UUID missionId) {
+        return ResponseEntity.ok(progressService.complete(missionId));
+    }
+}

--- a/backend/src/main/java/com/gitquest/backend/dto/progress/ProgressResponse.java
+++ b/backend/src/main/java/com/gitquest/backend/dto/progress/ProgressResponse.java
@@ -1,0 +1,28 @@
+package com.gitquest.backend.dto.progress;
+
+import com.gitquest.backend.entity.UserProgress;
+
+import java.time.OffsetDateTime;
+import java.util.UUID;
+
+public record ProgressResponse(
+        UUID id,
+        UUID missionId,
+        String missionTitle,
+        int missionLevel,
+        String status,
+        OffsetDateTime completedAt,
+        OffsetDateTime updatedAt
+) {
+    public static ProgressResponse from(UserProgress progress) {
+        return new ProgressResponse(
+                progress.getId(),
+                progress.getMission().getId(),
+                progress.getMission().getTitle(),
+                progress.getMission().getLevel(),
+                progress.getStatus().name(),
+                progress.getCompletedAt(),
+                progress.getUpdatedAt()
+        );
+    }
+}

--- a/backend/src/main/java/com/gitquest/backend/entity/UserProgress.java
+++ b/backend/src/main/java/com/gitquest/backend/entity/UserProgress.java
@@ -1,0 +1,60 @@
+package com.gitquest.backend.entity;
+
+import jakarta.persistence.*;
+import java.time.OffsetDateTime;
+import java.util.UUID;
+
+@Entity
+@Table(name = "user_progress")
+public class UserProgress {
+
+    public enum Status { NOT_STARTED, IN_PROGRESS, COMPLETED }
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "mission_id", nullable = false)
+    private Mission mission;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private Status status = Status.NOT_STARTED;
+
+    @Column(name = "completed_at")
+    private OffsetDateTime completedAt;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private OffsetDateTime createdAt;
+
+    @Column(name = "updated_at", nullable = false)
+    private OffsetDateTime updatedAt;
+
+    @PrePersist
+    protected void onCreate() {
+        createdAt = OffsetDateTime.now();
+        updatedAt = OffsetDateTime.now();
+    }
+
+    @PreUpdate
+    protected void onUpdate() {
+        updatedAt = OffsetDateTime.now();
+    }
+
+    public UUID getId() { return id; }
+    public User getUser() { return user; }
+    public void setUser(User user) { this.user = user; }
+    public Mission getMission() { return mission; }
+    public void setMission(Mission mission) { this.mission = mission; }
+    public Status getStatus() { return status; }
+    public void setStatus(Status status) { this.status = status; }
+    public OffsetDateTime getCompletedAt() { return completedAt; }
+    public void setCompletedAt(OffsetDateTime completedAt) { this.completedAt = completedAt; }
+    public OffsetDateTime getCreatedAt() { return createdAt; }
+    public OffsetDateTime getUpdatedAt() { return updatedAt; }
+}

--- a/backend/src/main/java/com/gitquest/backend/repository/UserProgressRepository.java
+++ b/backend/src/main/java/com/gitquest/backend/repository/UserProgressRepository.java
@@ -1,0 +1,13 @@
+package com.gitquest.backend.repository;
+
+import com.gitquest.backend.entity.UserProgress;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+public interface UserProgressRepository extends JpaRepository<UserProgress, UUID> {
+    List<UserProgress> findByUserId(UUID userId);
+    Optional<UserProgress> findByUserIdAndMissionId(UUID userId, UUID missionId);
+}

--- a/backend/src/main/java/com/gitquest/backend/security/SecurityUtil.java
+++ b/backend/src/main/java/com/gitquest/backend/security/SecurityUtil.java
@@ -1,0 +1,15 @@
+package com.gitquest.backend.security;
+
+import org.springframework.security.core.context.SecurityContextHolder;
+
+// JWT フィルターがセットした認証情報から、ログイン中のメールアドレスを取り出すユーティリティ
+public class SecurityUtil {
+
+    private SecurityUtil() {}
+
+    public static String getCurrentUserEmail() {
+        return SecurityContextHolder.getContext()
+                .getAuthentication()
+                .getName(); // UserDetailsServiceImpl で username にメールアドレスをセットしている
+    }
+}

--- a/backend/src/main/java/com/gitquest/backend/service/ProgressService.java
+++ b/backend/src/main/java/com/gitquest/backend/service/ProgressService.java
@@ -1,0 +1,94 @@
+package com.gitquest.backend.service;
+
+import com.gitquest.backend.dto.progress.ProgressResponse;
+import com.gitquest.backend.entity.Mission;
+import com.gitquest.backend.entity.User;
+import com.gitquest.backend.entity.UserProgress;
+import com.gitquest.backend.repository.MissionRepository;
+import com.gitquest.backend.repository.UserProgressRepository;
+import com.gitquest.backend.repository.UserRepository;
+import com.gitquest.backend.security.SecurityUtil;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.UUID;
+
+@Service
+public class ProgressService {
+
+    private final UserProgressRepository progressRepository;
+    private final UserRepository userRepository;
+    private final MissionRepository missionRepository;
+
+    public ProgressService(
+            UserProgressRepository progressRepository,
+            UserRepository userRepository,
+            MissionRepository missionRepository
+    ) {
+        this.progressRepository = progressRepository;
+        this.userRepository = userRepository;
+        this.missionRepository = missionRepository;
+    }
+
+    // ログイン中ユーザーの進捗一覧
+    @Transactional(readOnly = true)
+    public List<ProgressResponse> getMyProgress() {
+        User user = getCurrentUser();
+        return progressRepository.findByUserId(user.getId())
+                .stream()
+                .map(ProgressResponse::from)
+                .toList();
+    }
+
+    // ミッションを「開始中」にする
+    @Transactional
+    public ProgressResponse start(UUID missionId) {
+        User user = getCurrentUser();
+        Mission mission = getMission(missionId);
+
+        UserProgress progress = progressRepository
+                .findByUserIdAndMissionId(user.getId(), missionId)
+                .orElseGet(() -> {
+                    UserProgress p = new UserProgress();
+                    p.setUser(user);
+                    p.setMission(mission);
+                    return p;
+                });
+
+        progress.setStatus(UserProgress.Status.IN_PROGRESS);
+        return ProgressResponse.from(progressRepository.save(progress));
+    }
+
+    // ミッションを「完了」にする
+    @Transactional
+    public ProgressResponse complete(UUID missionId) {
+        User user = getCurrentUser();
+        Mission mission = getMission(missionId);
+
+        UserProgress progress = progressRepository
+                .findByUserIdAndMissionId(user.getId(), missionId)
+                .orElseGet(() -> {
+                    UserProgress p = new UserProgress();
+                    p.setUser(user);
+                    p.setMission(mission);
+                    return p;
+                });
+
+        progress.setStatus(UserProgress.Status.COMPLETED);
+        progress.setCompletedAt(OffsetDateTime.now());
+        return ProgressResponse.from(progressRepository.save(progress));
+    }
+
+    private User getCurrentUser() {
+        String email = SecurityUtil.getCurrentUserEmail();
+        return userRepository.findByEmail(email)
+                .orElseThrow(() -> new IllegalStateException("ログインユーザーが見つかりません"));
+    }
+
+    private Mission getMission(UUID missionId) {
+        return missionRepository.findById(missionId)
+                .orElseThrow(() -> new IllegalArgumentException("ミッションが見つかりません"));
+    }
+}

--- a/backend/src/main/resources/db/migration/V5__alter_progress_status_to_varchar.sql
+++ b/backend/src/main/resources/db/migration/V5__alter_progress_status_to_varchar.sql
@@ -1,0 +1,3 @@
+-- JPA の EnumType.STRING と互換性を持たせるため VARCHAR に変更
+ALTER TABLE user_progress ALTER COLUMN status TYPE VARCHAR(20) USING status::VARCHAR;
+DROP TYPE IF EXISTS progress_status CASCADE;


### PR DESCRIPTION
## Summary

- `UserProgress` エンティティ — `IN_PROGRESS` / `COMPLETED` の status を JPA `EnumType.STRING` で管理
- `ProgressService` — start / complete / 一覧取得のビジネスロジック
- `ProgressController` — REST エンドポイント 3 本
- V5 Flyway migration — PostgreSQL ENUM → VARCHAR(20) 変換（`CASCADE` で依存解消）

## Test plan

- [x] `POST /api/auth/register` でトークン取得
- [x] `POST /api/progress/{missionId}/start` → `status: IN_PROGRESS`
- [x] `POST /api/progress/{missionId}/complete` → `status: COMPLETED`, `completedAt` あり
- [x] `GET /api/progress` → 進捗一覧が返る

🤖 Generated with [Claude Code](https://claude.com/claude-code)