### PR TITLE
feat: フロント認証・ミッション一覧ページ実装 (#12)

### DIFF
--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -16,7 +16,7 @@ spring:
     locations: classpath:db/migration
 
 server:
-  port: 8080
+  port: 8085
 
 app:
   jwt:

--- a/frontend/layouts/default.vue
+++ b/frontend/layouts/default.vue
@@ -1,5 +1,69 @@
 <template>
   <div class="min-h-screen bg-gray-950 text-white">
+    <!-- ナビバー -->
+    <nav class="border-b border-gray-800 bg-gray-900/80 backdrop-blur-sm sticky top-0 z-50">
+      <div class="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8">
+        <div class="flex items-center justify-between h-16">
+          <!-- ロゴ -->
+          <NuxtLink to="/" class="flex items-center gap-2 text-green-400 hover:text-green-300 transition-colors">
+            <span class="text-xl font-bold tracking-tight">GitQuest</span>
+          </NuxtLink>
+
+          <!-- ナビリンク -->
+          <div class="flex items-center gap-2 sm:gap-4">
+            <template v-if="auth.isLoggedIn">
+              <NuxtLink
+                to="/missions"
+                class="text-sm text-gray-300 hover:text-white px-3 py-2 rounded-lg hover:bg-gray-800 transition-colors"
+              >
+                ミッション
+              </NuxtLink>
+              <div class="flex items-center gap-2 text-sm text-gray-400">
+                <span class="hidden sm:inline">{{ auth.username }}</span>
+              </div>
+              <button
+                class="text-sm text-gray-400 hover:text-red-400 px-3 py-2 rounded-lg hover:bg-gray-800 transition-colors"
+                @click="logout"
+              >
+                ログアウト
+              </button>
+            </template>
+            <template v-else>
+              <NuxtLink
+                to="/login"
+                class="text-sm text-gray-300 hover:text-white px-3 py-2 rounded-lg hover:bg-gray-800 transition-colors"
+              >
+                ログイン
+              </NuxtLink>
+              <NuxtLink
+                to="/register"
+                class="text-sm bg-green-600 hover:bg-green-500 text-white px-4 py-2 rounded-lg transition-colors"
+              >
+                新規登録
+              </NuxtLink>
+            </template>
+          </div>
+        </div>
+      </div>
+    </nav>
+
+    <!-- ページコンテンツ -->
     <slot />
   </div>
 </template>
+
+<script setup lang="ts">
+import { useAuthStore } from '~/stores/auth'
+
+const auth = useAuthStore()
+const router = useRouter()
+
+onMounted(() => {
+  auth.init()
+})
+
+function logout() {
+  auth.logout()
+  router.push('/')
+}
+</script>

--- a/frontend/middleware/auth.ts
+++ b/frontend/middleware/auth.ts
@@ -1,0 +1,10 @@
+import { useAuthStore } from '~/stores/auth'
+
+// ログインしていないユーザーを /login にリダイレクトするミドルウェア
+export default defineNuxtRouteMiddleware(() => {
+  const auth = useAuthStore()
+  auth.init()
+  if (!auth.isLoggedIn) {
+    return navigateTo('/login')
+  }
+})

--- a/frontend/nuxt.config.ts
+++ b/frontend/nuxt.config.ts
@@ -11,7 +11,7 @@ export default defineNuxtConfig({
 
   runtimeConfig: {
     public: {
-      apiBase: 'http://localhost:8080/api',
+      apiBase: 'http://localhost:8085/api',
     },
   },
 

--- a/frontend/pages/index.vue
+++ b/frontend/pages/index.vue
@@ -1,8 +1,78 @@
 <template>
-  <main class="flex flex-col items-center justify-center min-h-screen px-4">
-    <h1 class="text-5xl font-bold mb-4 text-green-400">GitQuest</h1>
-    <p class="text-gray-400 text-lg text-center">
-      Git コマンドを打ちながら、視覚的に Git を学ぼう
-    </p>
+  <main>
+    <!-- ヒーローセクション -->
+    <section class="relative overflow-hidden">
+      <!-- 背景のグラデーション -->
+      <div class="absolute inset-0 bg-gradient-to-br from-gray-950 via-gray-900 to-gray-950 pointer-events-none" />
+      <div class="absolute top-20 left-1/4 w-72 h-72 bg-green-500/10 rounded-full blur-3xl pointer-events-none" />
+      <div class="absolute bottom-10 right-1/4 w-96 h-96 bg-blue-500/10 rounded-full blur-3xl pointer-events-none" />
+
+      <div class="relative max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 pt-20 pb-24 text-center">
+        <span class="inline-block text-xs font-semibold tracking-widest text-green-400 uppercase mb-4 bg-green-400/10 px-3 py-1 rounded-full">
+          Git 学習プラットフォーム
+        </span>
+        <h1 class="text-4xl sm:text-5xl lg:text-6xl font-bold mb-6 leading-tight">
+          コマンドを打って、
+          <span class="text-green-400">Git</span>
+          を学ぼう
+        </h1>
+        <p class="text-gray-400 text-lg sm:text-xl max-w-2xl mx-auto mb-10">
+          ブラウザ上で Git コマンドを実行しながら、コミットグラフがリアルタイムで動く。
+          ミッションをクリアして Git マスターを目指そう。
+        </p>
+        <div class="flex flex-col sm:flex-row gap-4 justify-center">
+          <NuxtLink
+            to="/register"
+            class="px-8 py-3 bg-green-600 hover:bg-green-500 text-white font-semibold rounded-xl transition-all hover:scale-105 active:scale-95"
+          >
+            無料で始める
+          </NuxtLink>
+          <NuxtLink
+            to="/missions"
+            class="px-8 py-3 bg-gray-800 hover:bg-gray-700 text-gray-200 font-semibold rounded-xl transition-all hover:scale-105 active:scale-95"
+          >
+            ミッションを見る
+          </NuxtLink>
+        </div>
+      </div>
+    </section>
+
+    <!-- 特徴セクション -->
+    <section class="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 py-20">
+      <h2 class="text-2xl sm:text-3xl font-bold text-center mb-12 text-gray-100">
+        GitQuest でできること
+      </h2>
+      <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
+        <div
+          v-for="feature in features"
+          :key="feature.title"
+          class="bg-gray-900 border border-gray-800 rounded-2xl p-6 hover:border-green-500/50 transition-colors"
+        >
+          <div class="text-3xl mb-4">{{ feature.icon }}</div>
+          <h3 class="font-semibold text-lg mb-2 text-gray-100">{{ feature.title }}</h3>
+          <p class="text-gray-400 text-sm leading-relaxed">{{ feature.description }}</p>
+        </div>
+      </div>
+    </section>
   </main>
 </template>
+
+<script setup lang="ts">
+const features = [
+  {
+    icon: '💻',
+    title: '擬似ターミナル',
+    description: 'ブラウザ上で git コマンドを入力し、即座にフィードバックが返ってくる。',
+  },
+  {
+    icon: '🌳',
+    title: 'コミットグラフ',
+    description: 'コマンドを打つたびにコミット履歴がリアルタイムで可視化される。',
+  },
+  {
+    icon: '🎯',
+    title: 'ミッション学習',
+    description: '段階的なミッションをクリアしながら、実践的な Git スキルを身につける。',
+  },
+]
+</script>

--- a/frontend/pages/login.vue
+++ b/frontend/pages/login.vue
@@ -1,0 +1,80 @@
+<template>
+  <main class="flex items-center justify-center min-h-[calc(100vh-4rem)] px-4 py-12">
+    <div class="w-full max-w-md">
+      <!-- カード -->
+      <div class="bg-gray-900 border border-gray-800 rounded-2xl p-8">
+        <h1 class="text-2xl font-bold text-center mb-2">ログイン</h1>
+        <p class="text-gray-400 text-sm text-center mb-8">GitQuest へようこそ</p>
+
+        <!-- エラー -->
+        <div v-if="errorMessage" class="mb-6 bg-red-500/10 border border-red-500/30 text-red-400 text-sm rounded-xl px-4 py-3">
+          {{ errorMessage }}
+        </div>
+
+        <form @submit.prevent="handleLogin" class="flex flex-col gap-5">
+          <div>
+            <label class="block text-sm font-medium text-gray-300 mb-1.5">メールアドレス</label>
+            <input
+              v-model="form.email"
+              type="email"
+              required
+              placeholder="you@example.com"
+              class="w-full bg-gray-800 border border-gray-700 rounded-xl px-4 py-3 text-sm text-white placeholder-gray-500 focus:outline-none focus:border-green-500 transition-colors"
+            />
+          </div>
+          <div>
+            <label class="block text-sm font-medium text-gray-300 mb-1.5">パスワード</label>
+            <input
+              v-model="form.password"
+              type="password"
+              required
+              placeholder="••••••••"
+              class="w-full bg-gray-800 border border-gray-700 rounded-xl px-4 py-3 text-sm text-white placeholder-gray-500 focus:outline-none focus:border-green-500 transition-colors"
+            />
+          </div>
+
+          <button
+            type="submit"
+            :disabled="loading"
+            class="w-full bg-green-600 hover:bg-green-500 disabled:opacity-50 disabled:cursor-not-allowed text-white font-semibold py-3 rounded-xl transition-colors mt-2"
+          >
+            {{ loading ? 'ログイン中...' : 'ログイン' }}
+          </button>
+        </form>
+
+        <p class="text-center text-sm text-gray-400 mt-6">
+          アカウントをお持ちでない方は
+          <NuxtLink to="/register" class="text-green-400 hover:text-green-300 transition-colors">
+            新規登録
+          </NuxtLink>
+        </p>
+      </div>
+    </div>
+  </main>
+</template>
+
+<script setup lang="ts">
+import { useAuthStore } from '~/stores/auth'
+
+definePageMeta({ middleware: [] })
+
+const auth = useAuthStore()
+const router = useRouter()
+
+const form = reactive({ email: '', password: '' })
+const loading = ref(false)
+const errorMessage = ref('')
+
+async function handleLogin() {
+  loading.value = true
+  errorMessage.value = ''
+  try {
+    await auth.login(form)
+    router.push('/missions')
+  } catch {
+    errorMessage.value = 'メールアドレスまたはパスワードが正しくありません'
+  } finally {
+    loading.value = false
+  }
+}
+</script>

--- a/frontend/pages/missions/index.vue
+++ b/frontend/pages/missions/index.vue
@@ -1,0 +1,178 @@
+<template>
+  <main class="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 py-10">
+    <!-- ヘッダー -->
+    <div class="mb-10">
+      <h1 class="text-3xl font-bold mb-2">ミッション一覧</h1>
+      <p class="text-gray-400">レベルごとにミッションをクリアして Git マスターになろう</p>
+    </div>
+
+    <!-- ローディング -->
+    <div v-if="pending" class="flex justify-center py-20">
+      <div class="w-8 h-8 border-2 border-green-500 border-t-transparent rounded-full animate-spin" />
+    </div>
+
+    <!-- エラー -->
+    <div v-else-if="error" class="bg-red-500/10 border border-red-500/30 text-red-400 rounded-xl px-6 py-4">
+      ミッションの取得に失敗しました
+    </div>
+
+    <!-- ミッション一覧 -->
+    <div v-else class="flex flex-col gap-10">
+      <section
+        v-for="(missions, level) in missionsByLevel"
+        :key="level"
+      >
+        <!-- レベルヘッダー -->
+        <div class="flex items-center gap-3 mb-5">
+          <span
+            :class="levelBadgeClass(Number(level))"
+            class="text-xs font-bold px-3 py-1 rounded-full"
+          >
+            Lv.{{ level }}
+          </span>
+          <h2 class="text-lg font-semibold text-gray-200">{{ levelLabel(Number(level)) }}</h2>
+          <div class="flex-1 h-px bg-gray-800" />
+        </div>
+
+        <!-- ミッションカード -->
+        <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+          <div
+            v-for="mission in missions"
+            :key="mission.id"
+            class="bg-gray-900 border rounded-2xl p-6 flex flex-col gap-3 hover:border-green-500/50 transition-all hover:-translate-y-0.5"
+            :class="progressStatus(mission.id) === 'COMPLETED' ? 'border-green-600/40' : 'border-gray-800'"
+          >
+            <!-- ステータスバッジ -->
+            <div class="flex items-center justify-between">
+              <span
+                :class="statusClass(progressStatus(mission.id))"
+                class="text-xs font-semibold px-2.5 py-1 rounded-full"
+              >
+                {{ statusLabel(progressStatus(mission.id)) }}
+              </span>
+            </div>
+
+            <h3 class="font-semibold text-gray-100">{{ mission.title }}</h3>
+            <p class="text-sm text-gray-400 leading-relaxed flex-1">{{ mission.description }}</p>
+
+            <!-- ヒント -->
+            <div class="bg-gray-800 rounded-lg px-3 py-2 flex items-center gap-2">
+              <span class="text-xs text-gray-500">ヒント:</span>
+              <code class="text-xs text-green-400 font-mono">{{ mission.hint }}</code>
+            </div>
+
+            <!-- ボタン -->
+            <button
+              v-if="progressStatus(mission.id) !== 'COMPLETED'"
+              class="mt-1 w-full text-sm font-semibold py-2.5 rounded-xl transition-all"
+              :class="progressStatus(mission.id) === 'IN_PROGRESS'
+                ? 'bg-blue-600 hover:bg-blue-500 text-white'
+                : 'bg-gray-800 hover:bg-gray-700 text-gray-200'"
+              @click="handleStart(mission.id)"
+            >
+              {{ progressStatus(mission.id) === 'IN_PROGRESS' ? '進行中' : 'スタート' }}
+            </button>
+            <div
+              v-else
+              class="mt-1 w-full text-sm font-semibold py-2.5 rounded-xl bg-green-600/20 text-green-400 text-center"
+            >
+              完了
+            </div>
+          </div>
+        </div>
+      </section>
+    </div>
+  </main>
+</template>
+
+<script setup lang="ts">
+import { useAuthStore } from '~/stores/auth'
+
+definePageMeta({ middleware: ['auth'] })
+
+interface Mission {
+  id: string
+  level: number
+  orderIndex: number
+  title: string
+  description: string
+  hint: string
+}
+
+interface ProgressItem {
+  id: string
+  missionId: string
+  status: 'IN_PROGRESS' | 'COMPLETED'
+}
+
+const auth = useAuthStore()
+const config = useRuntimeConfig()
+
+// ミッション一覧を取得
+const { data: missionsByLevel, pending, error } = await useFetch<Record<string, Mission[]>>(
+  `${config.public.apiBase}/missions`,
+)
+
+// 自分の進捗を取得
+const progressList = ref<ProgressItem[]>([])
+
+async function fetchProgress() {
+  if (!auth.token) return
+  const data = await $fetch<ProgressItem[]>(`${config.public.apiBase}/progress`, {
+    headers: { Authorization: `Bearer ${auth.token}` },
+  })
+  progressList.value = data
+}
+
+onMounted(fetchProgress)
+
+// ミッション ID からステータスを返す
+function progressStatus(missionId: string): string {
+  return progressList.value.find((p) => p.missionId === missionId)?.status ?? 'NOT_STARTED'
+}
+
+async function handleStart(missionId: string) {
+  if (!auth.token) return
+  await $fetch(`${config.public.apiBase}/progress/${missionId}/start`, {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${auth.token}` },
+  })
+  await fetchProgress()
+}
+
+function levelLabel(level: number): string {
+  const labels: Record<number, string> = {
+    1: '入門 — 基本操作',
+    2: '初級 — ブランチ操作',
+    3: '中級 — 履歴・差分確認',
+  }
+  return labels[level] ?? `レベル ${level}`
+}
+
+function levelBadgeClass(level: number): string {
+  const classes: Record<number, string> = {
+    1: 'bg-green-500/15 text-green-400',
+    2: 'bg-blue-500/15 text-blue-400',
+    3: 'bg-purple-500/15 text-purple-400',
+  }
+  return classes[level] ?? 'bg-gray-700 text-gray-300'
+}
+
+function statusLabel(status: string): string {
+  const labels: Record<string, string> = {
+    NOT_STARTED: '未着手',
+    IN_PROGRESS: '進行中',
+    COMPLETED: '完了',
+  }
+  return labels[status] ?? '未着手'
+}
+
+function statusClass(status: string): string {
+  const classes: Record<string, string> = {
+    NOT_STARTED: 'bg-gray-700/50 text-gray-400',
+    IN_PROGRESS: 'bg-blue-500/15 text-blue-400',
+    COMPLETED: 'bg-green-500/15 text-green-400',
+  }
+  return classes[status] ?? 'bg-gray-700/50 text-gray-400'
+}
+</script>

--- a/frontend/pages/register.vue
+++ b/frontend/pages/register.vue
@@ -1,0 +1,90 @@
+<template>
+  <main class="flex items-center justify-center min-h-[calc(100vh-4rem)] px-4 py-12">
+    <div class="w-full max-w-md">
+      <div class="bg-gray-900 border border-gray-800 rounded-2xl p-8">
+        <h1 class="text-2xl font-bold text-center mb-2">新規登録</h1>
+        <p class="text-gray-400 text-sm text-center mb-8">アカウントを作成して始めよう</p>
+
+        <!-- エラー -->
+        <div v-if="errorMessage" class="mb-6 bg-red-500/10 border border-red-500/30 text-red-400 text-sm rounded-xl px-4 py-3">
+          {{ errorMessage }}
+        </div>
+
+        <form @submit.prevent="handleRegister" class="flex flex-col gap-5">
+          <div>
+            <label class="block text-sm font-medium text-gray-300 mb-1.5">ユーザー名</label>
+            <input
+              v-model="form.username"
+              type="text"
+              required
+              placeholder="gitmaster"
+              class="w-full bg-gray-800 border border-gray-700 rounded-xl px-4 py-3 text-sm text-white placeholder-gray-500 focus:outline-none focus:border-green-500 transition-colors"
+            />
+          </div>
+          <div>
+            <label class="block text-sm font-medium text-gray-300 mb-1.5">メールアドレス</label>
+            <input
+              v-model="form.email"
+              type="email"
+              required
+              placeholder="you@example.com"
+              class="w-full bg-gray-800 border border-gray-700 rounded-xl px-4 py-3 text-sm text-white placeholder-gray-500 focus:outline-none focus:border-green-500 transition-colors"
+            />
+          </div>
+          <div>
+            <label class="block text-sm font-medium text-gray-300 mb-1.5">パスワード</label>
+            <input
+              v-model="form.password"
+              type="password"
+              required
+              minlength="8"
+              placeholder="8文字以上"
+              class="w-full bg-gray-800 border border-gray-700 rounded-xl px-4 py-3 text-sm text-white placeholder-gray-500 focus:outline-none focus:border-green-500 transition-colors"
+            />
+          </div>
+
+          <button
+            type="submit"
+            :disabled="loading"
+            class="w-full bg-green-600 hover:bg-green-500 disabled:opacity-50 disabled:cursor-not-allowed text-white font-semibold py-3 rounded-xl transition-colors mt-2"
+          >
+            {{ loading ? '登録中...' : 'アカウントを作成' }}
+          </button>
+        </form>
+
+        <p class="text-center text-sm text-gray-400 mt-6">
+          すでにアカウントをお持ちの方は
+          <NuxtLink to="/login" class="text-green-400 hover:text-green-300 transition-colors">
+            ログイン
+          </NuxtLink>
+        </p>
+      </div>
+    </div>
+  </main>
+</template>
+
+<script setup lang="ts">
+import { useAuthStore } from '~/stores/auth'
+
+definePageMeta({ middleware: [] })
+
+const auth = useAuthStore()
+const router = useRouter()
+
+const form = reactive({ username: '', email: '', password: '' })
+const loading = ref(false)
+const errorMessage = ref('')
+
+async function handleRegister() {
+  loading.value = true
+  errorMessage.value = ''
+  try {
+    await auth.register(form)
+    router.push('/missions')
+  } catch {
+    errorMessage.value = '登録に失敗しました。メールアドレスが既に使用されている可能性があります'
+  } finally {
+    loading.value = false
+  }
+}
+</script>

--- a/frontend/stores/auth.ts
+++ b/frontend/stores/auth.ts
@@ -1,0 +1,102 @@
+import { defineStore } from 'pinia'
+
+interface AuthState {
+  token: string | null
+  userId: string | null
+  username: string | null
+  email: string | null
+}
+
+interface LoginPayload {
+  email: string
+  password: string
+}
+
+interface RegisterPayload {
+  username: string
+  email: string
+  password: string
+}
+
+interface AuthResponse {
+  accessToken: string
+  tokenType: string
+  userId: string
+  username: string
+  email: string
+}
+
+export const useAuthStore = defineStore('auth', {
+  state: (): AuthState => ({
+    token: null,
+    userId: null,
+    username: null,
+    email: null,
+  }),
+
+  getters: {
+    isLoggedIn: (state) => !!state.token,
+  },
+
+  actions: {
+    // localStorage からトークンを復元（ページリロード時）
+    init() {
+      if (import.meta.client) {
+        const token = localStorage.getItem('token')
+        const userId = localStorage.getItem('userId')
+        const username = localStorage.getItem('username')
+        const email = localStorage.getItem('email')
+        if (token) {
+          this.token = token
+          this.userId = userId
+          this.username = username
+          this.email = email
+        }
+      }
+    },
+
+    async login(payload: LoginPayload) {
+      const config = useRuntimeConfig()
+      const data = await $fetch<AuthResponse>(`${config.public.apiBase}/auth/login`, {
+        method: 'POST',
+        body: payload,
+      })
+      this._saveSession(data)
+    },
+
+    async register(payload: RegisterPayload) {
+      const config = useRuntimeConfig()
+      const data = await $fetch<AuthResponse>(`${config.public.apiBase}/auth/register`, {
+        method: 'POST',
+        body: payload,
+      })
+      this._saveSession(data)
+    },
+
+    logout() {
+      this.token = null
+      this.userId = null
+      this.username = null
+      this.email = null
+      if (import.meta.client) {
+        localStorage.removeItem('token')
+        localStorage.removeItem('userId')
+        localStorage.removeItem('username')
+        localStorage.removeItem('email')
+      }
+    },
+
+    _saveSession(data: AuthResponse) {
+      this.token = data.accessToken
+      this.userId = data.userId
+      this.username = data.username
+      this.email = data.email
+      if (import.meta.client) {
+        localStorage.setItem('token', data.accessToken)
+        localStorage.setItem('userId', data.userId)
+        localStorage.setItem('username', data.username)
+        localStorage.setItem('email', data.email)
+      }
+    },
+  },
+})


### PR DESCRIPTION
## Summary

- Pinia auth ストア — JWT トークンを localStorage に保存、ページリロード後も認証状態を維持
- `/login` / `/register` — 入力フォーム + エラー表示
- `/missions` — レベル別ミッション一覧、進捗ステータス（未着手 / 進行中 / 完了）、スタートボタン
- ナビバー — ログイン状態でメニュー切り替え
- 全ページ Tailwind ダークテーマ + レスポンシブ（sm: / lg: ブレークポイント）対応
- バックエンドポートを 8085 に変更（環境で 8080 が使用済みのため）

## Test plan

- [x] `/` ランディングページ表示
- [x] `/register` でユーザー登録 → `/missions` にリダイレクト
- [x] `/login` でログイン → `/missions` にリダイレクト
- [x] ミッション一覧表示（レベル 1-3）
- [x] スタートボタンで `IN_PROGRESS` に変化
- [x] 未ログインで `/missions` アクセス → `/login` にリダイレクト
- [x] ログアウトでトークン削除 → ナビバーが未ログイン表示に戻る

🤖 Generated with [Claude Code](https://claude.com/claude-code)