### PR TITLE
feat: UI 仕上げ — ダッシュボード・完了フロー・アニメーション (#18)

### DIFF
--- a/docs/learning/08_terminal_and_graph.md
+++ b/docs/learning/08_terminal_and_graph.md
@@ -1,0 +1,191 @@
+# 08 — 擬似ターミナル & SVG コミットグラフ
+
+## この章で学ぶこと
+
+- `ProcessBuilder` を使って Java からシェルコマンドを実行する方法
+- セッション管理（UUID + メモリ上の Map）
+- SVG の基本構造と Vue での動的描画
+- `git log` / `git branch` の出力を解析してグラフデータを作る方法
+
+---
+
+## 1. ProcessBuilder とは
+
+Java で「外部プログラムを起動する」ための仕組みです。  
+たとえば `git init` というコマンドを Java のコードから呼び出すことができます。
+
+```java
+ProcessBuilder pb = new ProcessBuilder("/bin/sh", "-c", "git init");
+pb.directory(workDir.toFile());   // コマンドを実行するディレクトリを指定
+pb.redirectErrorStream(true);     // エラー出力を標準出力に合流させる
+Process process = pb.start();     // コマンドを起動
+```
+
+`Process` オブジェクトから `getInputStream()` で出力を読み取れます。
+
+```java
+BufferedReader reader = new BufferedReader(
+    new InputStreamReader(process.getInputStream())
+);
+String output = reader.lines().collect(Collectors.joining("\n"));
+process.waitFor(); // コマンドが終了するまで待つ
+```
+
+---
+
+## 2. セッション管理
+
+GitQuest では「ユーザーごとに独立した git リポジトリ」を持つ必要があります。  
+そのため **セッション** という仕組みを使います。
+
+```
+フロントエンド                  バックエンド
+  |                               |
+  |--- POST /sessions ----------->|  UUID を発行・一時ディレクトリ作成
+  |<-- { sessionId: "abc-123" }---|
+  |                               |
+  |--- POST /sessions/abc-123/exec|  一時ディレクトリで git コマンド実行
+  |<-- { output, graph } ---------|
+```
+
+セッションデータはメモリ上の `ConcurrentHashMap` で管理します。
+
+```java
+// セッション ID → 作業ディレクトリ
+private final Map<String, Path> sessions = new ConcurrentHashMap<>();
+```
+
+`ConcurrentHashMap` = 複数のリクエストが同時に来ても安全な Map。
+
+一時ディレクトリは `Files.createTempDirectory()` で作ります。
+
+```java
+Path workDir = Files.createTempDirectory("gitquest-");
+// → /tmp/gitquest-abc12345/ のようなパスが作られる
+```
+
+---
+
+## 3. セキュリティ: 許可するコマンドを制限
+
+何でも実行できると危険です。`rm -rf /` などを実行されたら大変。  
+そこで許可リスト（allowlist）方式で制限しています。
+
+```java
+private static final Set<String> ALLOWED_COMMANDS = Set.of(
+    "git init", "git add", "git commit", "git branch",
+    "git checkout", "git merge", "git log", "git diff", "git status"
+);
+
+private boolean isAllowed(String command) {
+    String lower = command.toLowerCase();
+    return ALLOWED_COMMANDS.stream().anyMatch(lower::startsWith);
+}
+```
+
+`startsWith` で「コマンドの先頭が一致するか」を確認しています。  
+たとえば `git commit -m "hello"` は `"git commit"` で始まるので許可されます。
+
+---
+
+## 4. git log でコミット情報を取得
+
+`git log --format=...` でコミットの情報を整形して取得できます。
+
+```bash
+git log --all --format='%H|%h|%s|%an|%ci|%P'
+```
+
+| プレースホルダー | 意味 |
+|--------|------|
+| `%H` | 完全ハッシュ（40文字） |
+| `%h` | 短縮ハッシュ（7文字） |
+| `%s` | コミットメッセージの1行目 |
+| `%an` | 作者名 |
+| `%ci` | 日時 |
+| `%P` | 親コミットのハッシュ（スペース区切り） |
+
+出力例:
+```
+abc1234...|abc1234|first commit|GitQuest User|2026-04-21 10:00:00 +0900|
+def5678...|def5678|second commit|GitQuest User|2026-04-21 10:01:00 +0900|abc1234...
+```
+
+Java でこれを `|` で分割してオブジェクトに変換しています。
+
+---
+
+## 5. SVG でグラフを描く
+
+SVG (Scalable Vector Graphics) とは、HTML の中に直接書けるベクター画像形式です。
+
+```html
+<svg width="400" height="200">
+  <!-- 線を引く -->
+  <line x1="60" y1="30" x2="60" y2="90" stroke="#3b82f6" stroke-width="2" />
+
+  <!-- 円を描く -->
+  <circle cx="60" cy="30" r="10" fill="#22c55e" />
+
+  <!-- テキスト -->
+  <text x="80" y="34" fill="white" font-size="12">first commit</text>
+</svg>
+```
+
+GitQuest では各コミットを円（`<circle>`）で表し、親子関係を線（`<line>`）で繋いでいます。
+
+### Vue での動的 SVG
+
+`v-for` を使って JavaScript の配列から SVG 要素を自動生成しています。
+
+```vue
+<svg>
+  <circle
+    v-for="node in nodes"
+    :key="node.hash"
+    :cx="node.x"
+    :cy="node.y"
+    r="10"
+    fill="#3b82f6"
+  />
+</svg>
+```
+
+`:cx="node.x"` の `:` は Vue のバインディング記法。JavaScript の値を属性に渡せます。
+
+---
+
+## 6. コンポーネント間のデータの流れ
+
+```
+pages/missions/[id].vue
+  ├── <TerminalPane>  → コマンドを実行して結果をもらう
+  │      emit('graphUpdated', res.graph)
+  │
+  └── <CommitGraph>   ← graphData を props で受け取って描画
+```
+
+Vue では「上から下へ `props` でデータを渡し、下から上へ `emit` でイベントを伝える」のが基本です。
+
+```
+親コンポーネント
+  │  :graph="graphData"  ← props（データを渡す）
+  ↓
+子コンポーネント
+  │  emit('graphUpdated', data)  ← emit（イベントを上に伝える）
+  ↑
+親コンポーネント
+```
+
+---
+
+## まとめ
+
+| 技術 | 使った場面 |
+|------|-----------|
+| ProcessBuilder | Java から git コマンドを実行 |
+| ConcurrentHashMap | セッション（UUID → 一時ディレクトリ）の管理 |
+| 許可リスト | セキュリティ: git 以外のコマンドを弾く |
+| git log --format | コミット情報を構造化データとして取得 |
+| SVG | ブラウザ上でコミットグラフを描画 |
+| Vue emit/props | 親子コンポーネント間のデータ連携 |

--- a/frontend/app.vue
+++ b/frontend/app.vue
@@ -1,7 +1,22 @@
 <template>
   <div>
     <NuxtLayout>
-      <NuxtPage />
+      <NuxtPage :transition="{ name: 'page', mode: 'out-in' }" />
     </NuxtLayout>
   </div>
 </template>
+
+<style>
+.page-enter-active,
+.page-leave-active {
+  transition: opacity 0.15s ease, transform 0.15s ease;
+}
+.page-enter-from {
+  opacity: 0;
+  transform: translateY(6px);
+}
+.page-leave-to {
+  opacity: 0;
+  transform: translateY(-6px);
+}
+</style>

--- a/frontend/layouts/default.vue
+++ b/frontend/layouts/default.vue
@@ -13,14 +13,17 @@
           <div class="flex items-center gap-2 sm:gap-4">
             <template v-if="auth.isLoggedIn">
               <NuxtLink
+                to="/dashboard"
+                class="text-sm text-gray-300 hover:text-white px-3 py-2 rounded-lg hover:bg-gray-800 transition-colors hidden sm:block"
+              >
+                ダッシュボード
+              </NuxtLink>
+              <NuxtLink
                 to="/missions"
                 class="text-sm text-gray-300 hover:text-white px-3 py-2 rounded-lg hover:bg-gray-800 transition-colors"
               >
                 ミッション
               </NuxtLink>
-              <div class="flex items-center gap-2 text-sm text-gray-400">
-                <span class="hidden sm:inline">{{ auth.username }}</span>
-              </div>
               <button
                 class="text-sm text-gray-400 hover:text-red-400 px-3 py-2 rounded-lg hover:bg-gray-800 transition-colors"
                 @click="logout"

--- a/frontend/pages/dashboard.vue
+++ b/frontend/pages/dashboard.vue
@@ -1,0 +1,192 @@
+<template>
+  <main class="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 py-10">
+    <!-- ヘッダー -->
+    <div class="mb-10">
+      <p class="text-gray-400 text-sm mb-1">おかえり、</p>
+      <h1 class="text-3xl font-bold">{{ auth.username }}</h1>
+    </div>
+
+    <!-- ローディング -->
+    <div v-if="pending" class="flex justify-center py-20">
+      <div class="w-8 h-8 border-2 border-green-500 border-t-transparent rounded-full animate-spin" />
+    </div>
+
+    <template v-else>
+      <!-- サマリーカード -->
+      <div class="grid grid-cols-2 lg:grid-cols-4 gap-4 mb-10">
+        <div
+          v-for="stat in stats"
+          :key="stat.label"
+          class="bg-gray-900 border border-gray-800 rounded-2xl p-5 flex flex-col gap-1"
+        >
+          <span class="text-2xl font-bold" :class="stat.color">{{ stat.value }}</span>
+          <span class="text-xs text-gray-500">{{ stat.label }}</span>
+        </div>
+      </div>
+
+      <!-- レベル別進捗 -->
+      <section class="mb-10">
+        <h2 class="text-lg font-semibold mb-5 text-gray-200">レベル別クリア率</h2>
+        <div class="flex flex-col gap-4">
+          <div
+            v-for="lv in levelStats"
+            :key="lv.level"
+            class="bg-gray-900 border border-gray-800 rounded-2xl p-5"
+          >
+            <div class="flex items-center justify-between mb-3">
+              <div class="flex items-center gap-3">
+                <span :class="levelBadgeClass(lv.level)" class="text-xs font-bold px-3 py-1 rounded-full">
+                  Lv.{{ lv.level }}
+                </span>
+                <span class="text-sm text-gray-300">{{ levelLabel(lv.level) }}</span>
+              </div>
+              <span class="text-sm font-semibold text-gray-300">{{ lv.cleared }} / {{ lv.total }}</span>
+            </div>
+            <!-- プログレスバー -->
+            <div class="h-2 bg-gray-800 rounded-full overflow-hidden">
+              <div
+                class="h-full rounded-full transition-all duration-700"
+                :class="lv.cleared === lv.total ? 'bg-green-500' : 'bg-blue-500'"
+                :style="{ width: `${lv.total > 0 ? (lv.cleared / lv.total) * 100 : 0}%` }"
+              />
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <!-- 最近クリアしたミッション -->
+      <section v-if="recentCompleted.length > 0">
+        <h2 class="text-lg font-semibold mb-5 text-gray-200">最近クリアしたミッション</h2>
+        <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+          <div
+            v-for="p in recentCompleted"
+            :key="p.id"
+            class="bg-gray-900 border border-green-600/30 rounded-2xl p-5 flex flex-col gap-2"
+          >
+            <div class="flex items-center gap-2">
+              <span class="text-xs font-semibold text-green-400">完了</span>
+              <span class="text-xs text-gray-500">Lv.{{ p.missionLevel }}</span>
+            </div>
+            <p class="font-medium text-gray-100 text-sm">{{ p.missionTitle }}</p>
+            <p class="text-xs text-gray-500">
+              {{ formatDate(p.completedAt) }}
+            </p>
+          </div>
+        </div>
+      </section>
+
+      <!-- まだ何もない場合 -->
+      <div v-else-if="progressList.length === 0" class="text-center py-16">
+        <p class="text-gray-500 mb-4">まだミッションを始めていません</p>
+        <NuxtLink
+          to="/missions"
+          class="px-6 py-2.5 bg-green-600 hover:bg-green-500 text-white font-semibold rounded-xl transition-colors text-sm"
+        >
+          ミッション一覧へ
+        </NuxtLink>
+      </div>
+    </template>
+  </main>
+</template>
+
+<script setup lang="ts">
+import { useAuthStore } from '~/stores/auth'
+
+definePageMeta({ middleware: ['auth'] })
+
+interface ProgressItem {
+  id: string
+  missionId: string
+  missionTitle: string
+  missionLevel: number
+  status: 'IN_PROGRESS' | 'COMPLETED'
+  completedAt: string | null
+  updatedAt: string
+}
+
+interface Mission {
+  id: string
+  level: number
+  title: string
+}
+
+const auth = useAuthStore()
+const config = useRuntimeConfig()
+
+const { data: progressRaw, pending } = await useFetch<ProgressItem[]>(
+  `${config.public.apiBase}/progress`,
+  { headers: { Authorization: `Bearer ${auth.token}` } }
+)
+
+const { data: missionsByLevel } = await useFetch<Record<string, Mission[]>>(
+  `${config.public.apiBase}/missions`
+)
+
+const progressList = computed(() => progressRaw.value ?? [])
+
+// 全ミッション数
+const allMissions = computed(() => {
+  if (!missionsByLevel.value) return []
+  return Object.values(missionsByLevel.value).flat()
+})
+
+const completedCount = computed(() => progressList.value.filter((p) => p.status === 'COMPLETED').length)
+const inProgressCount = computed(() => progressList.value.filter((p) => p.status === 'IN_PROGRESS').length)
+
+const stats = computed(() => [
+  { label: 'クリア済み', value: completedCount.value, color: 'text-green-400' },
+  { label: '進行中', value: inProgressCount.value, color: 'text-blue-400' },
+  { label: '総ミッション', value: allMissions.value.length, color: 'text-gray-300' },
+  {
+    label: 'クリア率',
+    value: allMissions.value.length > 0
+      ? `${Math.round((completedCount.value / allMissions.value.length) * 100)}%`
+      : '0%',
+    color: 'text-yellow-400',
+  },
+])
+
+// レベル別進捗
+const levelStats = computed(() => {
+  if (!missionsByLevel.value) return []
+  return Object.entries(missionsByLevel.value).map(([level, missions]) => {
+    const cleared = missions.filter((m) =>
+      progressList.value.some((p) => p.missionId === m.id && p.status === 'COMPLETED')
+    ).length
+    return { level: Number(level), total: missions.length, cleared }
+  }).sort((a, b) => a.level - b.level)
+})
+
+// 最近クリアしたミッション（新しい順に最大 6 件）
+const recentCompleted = computed(() =>
+  progressList.value
+    .filter((p) => p.status === 'COMPLETED' && p.completedAt)
+    .sort((a, b) => new Date(b.completedAt!).getTime() - new Date(a.completedAt!).getTime())
+    .slice(0, 6)
+)
+
+function levelLabel(level: number): string {
+  const labels: Record<number, string> = {
+    1: '入門 — 基本操作',
+    2: '初級 — ブランチ操作',
+    3: '中級 — 履歴・差分確認',
+  }
+  return labels[level] ?? `レベル ${level}`
+}
+
+function levelBadgeClass(level: number): string {
+  const classes: Record<number, string> = {
+    1: 'bg-green-500/15 text-green-400',
+    2: 'bg-blue-500/15 text-blue-400',
+    3: 'bg-purple-500/15 text-purple-400',
+  }
+  return classes[level] ?? 'bg-gray-700 text-gray-300'
+}
+
+function formatDate(iso: string | null): string {
+  if (!iso) return ''
+  return new Date(iso).toLocaleDateString('ja-JP', {
+    year: 'numeric', month: 'short', day: 'numeric',
+  })
+}
+</script>

--- a/frontend/pages/missions/[id].vue
+++ b/frontend/pages/missions/[id].vue
@@ -1,17 +1,66 @@
 <template>
-  <div class="flex flex-col h-[calc(100vh-4rem)]">
+  <div class="flex flex-col h-[calc(100vh-4rem)] relative">
+    <!-- 完了お祝いオーバーレイ -->
+    <Transition name="celebration">
+      <div
+        v-if="showCelebration"
+        class="absolute inset-0 z-50 flex items-center justify-center bg-gray-950/90 backdrop-blur-sm"
+      >
+        <div class="text-center px-8">
+          <div class="text-6xl mb-4 animate-bounce">🎉</div>
+          <h2 class="text-3xl font-bold text-green-400 mb-2">ミッション完了！</h2>
+          <p class="text-gray-300 mb-8">{{ mission?.title }}</p>
+          <div class="flex flex-col sm:flex-row gap-3 justify-center">
+            <NuxtLink
+              to="/missions"
+              class="px-6 py-3 bg-green-600 hover:bg-green-500 text-white font-semibold rounded-xl transition-colors"
+            >
+              ミッション一覧へ
+            </NuxtLink>
+            <button
+              class="px-6 py-3 bg-gray-800 hover:bg-gray-700 text-gray-200 font-semibold rounded-xl transition-colors"
+              @click="showCelebration = false"
+            >
+              続ける
+            </button>
+          </div>
+        </div>
+      </div>
+    </Transition>
+
     <!-- ヘッダー -->
     <div class="border-b border-gray-800 bg-gray-900 px-4 sm:px-6 py-4 shrink-0">
-      <div class="max-w-7xl mx-auto flex items-center gap-4">
-        <NuxtLink to="/missions" class="text-gray-400 hover:text-white transition-colors text-sm">
-          ← ミッション一覧
-        </NuxtLink>
-        <div v-if="mission" class="flex items-center gap-3">
-          <span class="text-xs font-semibold px-2 py-0.5 rounded-full bg-green-500/15 text-green-400">
-            Lv.{{ mission.level }}
-          </span>
-          <h1 class="font-semibold text-gray-100">{{ mission.title }}</h1>
+      <div class="max-w-7xl mx-auto flex items-center justify-between">
+        <div class="flex items-center gap-4">
+          <NuxtLink to="/missions" class="text-gray-400 hover:text-white transition-colors text-sm">
+            ← 一覧
+          </NuxtLink>
+          <div v-if="mission" class="flex items-center gap-3">
+            <span class="text-xs font-semibold px-2 py-0.5 rounded-full bg-green-500/15 text-green-400">
+              Lv.{{ mission.level }}
+            </span>
+            <h1 class="font-semibold text-gray-100 text-sm sm:text-base">{{ mission.title }}</h1>
+          </div>
         </div>
+
+        <!-- 完了ボタン -->
+        <button
+          v-if="progressStatus !== 'COMPLETED'"
+          :disabled="completing"
+          class="text-sm font-semibold px-4 py-2 rounded-xl transition-all"
+          :class="progressStatus === 'IN_PROGRESS'
+            ? 'bg-green-600 hover:bg-green-500 text-white'
+            : 'bg-gray-800 hover:bg-gray-700 text-gray-300'"
+          @click="handleComplete"
+        >
+          {{ completing ? '記録中...' : 'ミッション完了' }}
+        </button>
+        <span
+          v-else
+          class="text-sm font-semibold px-4 py-2 rounded-xl bg-green-600/20 text-green-400"
+        >
+          完了済み
+        </span>
       </div>
     </div>
 
@@ -47,7 +96,8 @@
 </template>
 
 <script setup lang="ts">
-import type { TerminalCommandResponse } from '~/types/terminal'
+import { useAuthStore } from '~/stores/auth'
+import type { GraphData } from '~/types/terminal'
 
 definePageMeta({ middleware: ['auth'] })
 
@@ -59,8 +109,15 @@ interface Mission {
   hint: string
 }
 
+interface ProgressItem {
+  id: string
+  missionId: string
+  status: 'IN_PROGRESS' | 'COMPLETED'
+}
+
 const route = useRoute()
 const config = useRuntimeConfig()
+const auth = useAuthStore()
 const missionId = route.params.id as string
 
 // ミッション情報を取得
@@ -76,6 +133,18 @@ const mission = computed(() => {
   return null
 })
 
+// 進捗状態
+const progressStatus = ref<string>('NOT_STARTED')
+
+async function fetchProgress() {
+  if (!auth.token) return
+  const list = await $fetch<ProgressItem[]>(`${config.public.apiBase}/progress`, {
+    headers: { Authorization: `Bearer ${auth.token}` },
+  }).catch(() => [] as ProgressItem[])
+  const found = list.find((p) => p.missionId === missionId)
+  progressStatus.value = found?.status ?? 'NOT_STARTED'
+}
+
 // ターミナルセッション
 const sessionId = ref<string | null>(null)
 
@@ -85,13 +154,43 @@ async function createSession() {
     { method: 'POST' }
   )
   sessionId.value = res.sessionId
+
+  // セッション作成と同時に「開始中」にする
+  if (auth.token && progressStatus.value === 'NOT_STARTED') {
+    await $fetch(`${config.public.apiBase}/progress/${missionId}/start`, {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${auth.token}` },
+    }).catch(() => {})
+    progressStatus.value = 'IN_PROGRESS'
+  }
 }
 
 // グラフデータ
-const graphData = ref<TerminalCommandResponse['graph'] | null>(null)
+const graphData = ref<GraphData | null>(null)
 
 function onGraphUpdated(graph: unknown) {
-  graphData.value = graph as TerminalCommandResponse['graph']
+  graphData.value = graph as GraphData
+}
+
+// ミッション完了
+const completing = ref(false)
+const showCelebration = ref(false)
+
+async function handleComplete() {
+  if (!auth.token || completing.value) return
+  completing.value = true
+  try {
+    await $fetch(`${config.public.apiBase}/progress/${missionId}/complete`, {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${auth.token}` },
+    })
+    progressStatus.value = 'COMPLETED'
+    showCelebration.value = true
+  } catch {
+    // 失敗しても静かに無視
+  } finally {
+    completing.value = false
+  }
 }
 
 // ページを離れるときにセッションを破棄
@@ -103,5 +202,19 @@ onUnmounted(async () => {
   }
 })
 
-onMounted(createSession)
+onMounted(async () => {
+  await fetchProgress()
+  await createSession()
+})
 </script>
+
+<style scoped>
+.celebration-enter-active,
+.celebration-leave-active {
+  transition: opacity 0.3s ease;
+}
+.celebration-enter-from,
+.celebration-leave-to {
+  opacity: 0;
+}
+</style>

--- a/frontend/pages/missions/index.vue
+++ b/frontend/pages/missions/index.vue
@@ -16,8 +16,22 @@
       ミッションの取得に失敗しました
     </div>
 
+    <!-- 全体進捗バー -->
+    <div v-if="!pending && !error" class="mb-8 bg-gray-900 border border-gray-800 rounded-2xl p-5">
+      <div class="flex items-center justify-between mb-3">
+        <span class="text-sm font-medium text-gray-300">全体の進捗</span>
+        <span class="text-sm font-semibold text-green-400">{{ completedCount }} / {{ totalCount }} クリア</span>
+      </div>
+      <div class="h-2.5 bg-gray-800 rounded-full overflow-hidden">
+        <div
+          class="h-full bg-gradient-to-r from-green-600 to-green-400 rounded-full transition-all duration-700"
+          :style="{ width: `${totalCount > 0 ? (completedCount / totalCount) * 100 : 0}%` }"
+        />
+      </div>
+    </div>
+
     <!-- ミッション一覧 -->
-    <div v-else class="flex flex-col gap-10">
+    <div v-if="!pending && !error" class="flex flex-col gap-10">
       <section
         v-for="(missions, level) in missionsByLevel"
         :key="level"
@@ -121,6 +135,15 @@ async function fetchProgress() {
 }
 
 onMounted(fetchProgress)
+
+// 全ミッション数・クリア数
+const totalCount = computed(() => {
+  if (!missionsByLevel.value) return 0
+  return Object.values(missionsByLevel.value).flat().length
+})
+const completedCount = computed(() =>
+  progressList.value.filter((p) => p.status === 'COMPLETED').length
+)
 
 // ミッション ID からステータスを返す
 function progressStatus(missionId: string): string {


### PR DESCRIPTION
## Summary

- `pages/dashboard.vue` — 進捗サマリー（クリア数・クリア率）、レベル別プログレスバー、最近クリアしたミッション一覧
- `pages/missions/[id].vue` — ミッション完了ボタン + お祝いオーバーレイ（フェードイン）、ページ開封時に自動で「開始中」に更新
- `pages/missions/index.vue` — 全体進捗バー（グラデーション）追加
- `layouts/default.vue` — ナビバーにダッシュボードリンク追加
- `app.vue` — ページ遷移フェードアニメーション
- `docs/learning/08_terminal_and_graph.md` — ProcessBuilder・SVG・Vue emit の学習解説

## Test plan

- [x] `/dashboard` でクリア数・レベル別バーが表示される
- [x] ミッション詳細で「ミッション完了」ボタンを押すとお祝いが表示される
- [x] ミッション一覧に全体進捗バーが表示される
- [x] ログイン後ナビバーに「ダッシュボード」が表示される
- [x] ページ遷移時にフェードアニメーションが動く

🤖 Generated with [Claude Code](https://claude.com/claude-code)