### PR TITLE
feat: ゲーミフィケーション — XP・ランク・バッジ・連続学習記録

### DIFF
--- a/frontend/composables/useGameStats.ts
+++ b/frontend/composables/useGameStats.ts
@@ -1,0 +1,153 @@
+// ゲーミフィケーション (XP・ランク・バッジ・連続学習) の計算ロジック
+// すべて進捗 API とミッション API のデータから導出する
+
+export interface ProgressEntry {
+  missionId: string
+  status: 'IN_PROGRESS' | 'COMPLETED'
+  completedAt: string | null
+}
+
+export interface MissionEntry {
+  id: string
+  level: number
+  orderIndex: number
+  title: string
+}
+
+export interface Rank {
+  name: string
+  icon: string
+  minXp: number
+}
+
+export interface Badge {
+  id: string
+  icon: string
+  name: string
+  description: string
+  earned: boolean
+}
+
+// ランク定義 (XP のしきい値順)
+export const RANKS: Rank[] = [
+  { name: 'みならい冒険者', icon: '🥚', minXp: 0 },
+  { name: 'コミット使い', icon: '🌱', minXp: 300 },
+  { name: 'ブランチ騎士', icon: '🛡️', minXp: 800 },
+  { name: 'マージ魔導士', icon: '🔮', minXp: 1500 },
+  { name: 'Git マスター', icon: '👑', minXp: 2400 },
+]
+
+// ミッション 1 件あたりの XP はレベル × 100
+export function xpForLevel(level: number): number {
+  return level * 100
+}
+
+export function useGameStats(
+  progress: () => ProgressEntry[],
+  missions: () => MissionEntry[],
+) {
+  const completedMissions = computed(() => {
+    const completedIds = new Set(
+      progress().filter((p) => p.status === 'COMPLETED').map((p) => p.missionId),
+    )
+    return missions().filter((m) => completedIds.has(m.id))
+  })
+
+  // ─── XP とランク ───
+
+  const totalXp = computed(() =>
+    completedMissions.value.reduce((sum, m) => sum + xpForLevel(m.level), 0),
+  )
+
+  const currentRank = computed(() => {
+    let rank = RANKS[0]
+    for (const r of RANKS) {
+      if (totalXp.value >= r.minXp) rank = r
+    }
+    return rank
+  })
+
+  const nextRank = computed(() => {
+    const idx = RANKS.indexOf(currentRank.value)
+    return idx < RANKS.length - 1 ? RANKS[idx + 1] : null
+  })
+
+  // 次のランクまでの進捗率 (0〜100)
+  const rankProgress = computed(() => {
+    if (!nextRank.value) return 100
+    const span = nextRank.value.minXp - currentRank.value.minXp
+    const gained = totalXp.value - currentRank.value.minXp
+    return Math.min(100, Math.round((gained / span) * 100))
+  })
+
+  // ─── バッジ ───
+
+  const badges = computed<Badge[]>(() => {
+    const all = missions()
+    const done = completedMissions.value
+    const levelDone = (lv: number) => {
+      const inLevel = all.filter((m) => m.level === lv)
+      return inLevel.length > 0 && inLevel.every((m) => done.some((d) => d.id === m.id))
+    }
+    const missionDone = (lv: number, order: number) =>
+      done.some((m) => m.level === lv && m.orderIndex === order)
+
+    return [
+      {
+        id: 'first-step', icon: '🎯', name: 'はじめの一歩',
+        description: '最初のミッションをクリア', earned: done.length >= 1,
+      },
+      {
+        id: 'lv1-clear', icon: '🌱', name: 'Git 入門者',
+        description: 'Lv1 のミッションをすべてクリア', earned: levelDone(1),
+      },
+      {
+        id: 'lv2-clear', icon: '🌿', name: 'ブランチ使い',
+        description: 'Lv2 のミッションをすべてクリア', earned: levelDone(2),
+      },
+      {
+        id: 'lv3-clear', icon: '🔍', name: '履歴の探偵',
+        description: 'Lv3 のミッションをすべてクリア', earned: levelDone(3),
+      },
+      {
+        id: 'conflict-buster', icon: '⚔️', name: 'コンフリクトバスター',
+        description: 'マージコンフリクトを解決', earned: missionDone(4, 1),
+      },
+      {
+        id: 'time-traveler', icon: '⏪', name: 'タイムトラベラー',
+        description: 'コミットの修正・取り消しを習得', earned: missionDone(4, 2) && missionDone(4, 3),
+      },
+      {
+        id: 'all-clear', icon: '👑', name: 'GitQuest マスター',
+        description: '全ミッションをクリア',
+        earned: all.length > 0 && done.length === all.length,
+      },
+    ]
+  })
+
+  const earnedBadgeCount = computed(() => badges.value.filter((b) => b.earned).length)
+
+  // ─── 連続学習日数 (ストリーク) ───
+
+  const streak = computed(() => {
+    const days = new Set(
+      progress()
+        .filter((p) => p.status === 'COMPLETED' && p.completedAt)
+        .map((p) => new Date(p.completedAt!).toDateString()),
+    )
+    if (days.size === 0) return 0
+
+    let count = 0
+    const cursor = new Date()
+    // 今日まだクリアしていなくても、昨日までの連続は維持扱いにする
+    if (!days.has(cursor.toDateString())) cursor.setDate(cursor.getDate() - 1)
+
+    while (days.has(cursor.toDateString())) {
+      count++
+      cursor.setDate(cursor.getDate() - 1)
+    }
+    return count
+  })
+
+  return { totalXp, currentRank, nextRank, rankProgress, badges, earnedBadgeCount, streak }
+}

--- a/frontend/pages/dashboard.vue
+++ b/frontend/pages/dashboard.vue
@@ -1,7 +1,7 @@
 <template>
   <main class="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 py-10">
     <!-- ヘッダー -->
-    <div class="mb-10">
+    <div class="mb-8">
       <p class="text-gray-400 text-sm mb-1">おかえり、</p>
       <h1 class="text-3xl font-bold">{{ auth.username }}</h1>
     </div>
@@ -12,6 +12,43 @@
     </div>
 
     <template v-else>
+      <!-- ランク & XP カード -->
+      <section class="mb-8 bg-gray-900 border border-gray-800 rounded-2xl p-6 sm:p-8 relative overflow-hidden">
+        <div class="absolute -top-16 -right-16 w-64 h-64 bg-green-500/10 rounded-full blur-3xl pointer-events-none" />
+        <div class="relative flex flex-col sm:flex-row sm:items-center gap-6">
+          <!-- ランクアイコン -->
+          <div class="w-20 h-20 rounded-2xl bg-gray-800 border border-gray-700 flex items-center justify-center text-4xl shrink-0 mx-auto sm:mx-0">
+            {{ game.currentRank.value.icon }}
+          </div>
+          <div class="flex-1 text-center sm:text-left">
+            <p class="text-xs text-gray-500 mb-1 tracking-wide uppercase">現在のランク</p>
+            <h2 class="text-2xl font-bold text-gray-100 mb-3">{{ game.currentRank.value.name }}</h2>
+            <!-- XP バー -->
+            <div class="flex items-center gap-3">
+              <div class="flex-1 h-2.5 bg-gray-800 rounded-full overflow-hidden">
+                <div
+                  class="h-full bg-linear-to-r from-green-600 to-green-400 rounded-full transition-all duration-700"
+                  :style="{ width: `${game.rankProgress.value}%` }"
+                />
+              </div>
+              <span class="text-sm font-semibold text-green-400 shrink-0">{{ game.totalXp.value }} XP</span>
+            </div>
+            <p v-if="game.nextRank.value" class="text-xs text-gray-500 mt-2">
+              次のランク「{{ game.nextRank.value.icon }} {{ game.nextRank.value.name }}」まで
+              あと {{ game.nextRank.value.minXp - game.totalXp.value }} XP
+            </p>
+            <p v-else class="text-xs text-yellow-400 mt-2">最高ランク到達！おめでとう 🎉</p>
+          </div>
+          <!-- ストリーク -->
+          <div class="text-center bg-gray-800/60 border border-gray-700/50 rounded-2xl px-6 py-4 shrink-0 mx-auto sm:mx-0">
+            <p class="text-3xl font-bold" :class="game.streak.value > 0 ? 'text-orange-400' : 'text-gray-600'">
+              🔥 {{ game.streak.value }}
+            </p>
+            <p class="text-xs text-gray-500 mt-1">連続学習日数</p>
+          </div>
+        </div>
+      </section>
+
       <!-- サマリーカード -->
       <div class="grid grid-cols-2 lg:grid-cols-4 gap-4 mb-10">
         <div
@@ -23,6 +60,30 @@
           <span class="text-xs text-gray-500">{{ stat.label }}</span>
         </div>
       </div>
+
+      <!-- バッジ (実績) -->
+      <section class="mb-10">
+        <div class="flex items-center justify-between mb-5">
+          <h2 class="text-lg font-semibold text-gray-200">実績バッジ</h2>
+          <span class="text-sm text-gray-500">{{ game.earnedBadgeCount.value }} / {{ game.badges.value.length }} 獲得</span>
+        </div>
+        <div class="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 gap-4">
+          <div
+            v-for="badge in game.badges.value"
+            :key="badge.id"
+            class="rounded-2xl p-5 border flex flex-col gap-2 transition-all"
+            :class="badge.earned
+              ? 'bg-gray-900 border-yellow-600/40 hover:border-yellow-500/60'
+              : 'bg-gray-900/40 border-gray-800 opacity-50'"
+          >
+            <span class="text-3xl" :class="{ grayscale: !badge.earned }">{{ badge.icon }}</span>
+            <p class="font-semibold text-sm" :class="badge.earned ? 'text-gray-100' : 'text-gray-500'">
+              {{ badge.name }}
+            </p>
+            <p class="text-xs text-gray-500 leading-relaxed">{{ badge.description }}</p>
+          </div>
+        </div>
+      </section>
 
       <!-- レベル別進捗 -->
       <section class="mb-10">
@@ -42,7 +103,6 @@
               </div>
               <span class="text-sm font-semibold text-gray-300">{{ lv.cleared }} / {{ lv.total }}</span>
             </div>
-            <!-- プログレスバー -->
             <div class="h-2 bg-gray-800 rounded-full overflow-hidden">
               <div
                 class="h-full rounded-full transition-all duration-700"
@@ -66,6 +126,7 @@
             <div class="flex items-center gap-2">
               <span class="text-xs font-semibold text-green-400">完了</span>
               <span class="text-xs text-gray-500">Lv.{{ p.missionLevel }}</span>
+              <span class="ml-auto text-xs font-semibold text-yellow-400">+{{ xpForLevel(p.missionLevel) }} XP</span>
             </div>
             <p class="font-medium text-gray-100 text-sm">{{ p.missionTitle }}</p>
             <p class="text-xs text-gray-500">
@@ -91,6 +152,7 @@
 
 <script setup lang="ts">
 import { useAuthStore } from '~/stores/auth'
+import { useGameStats, xpForLevel } from '~/composables/useGameStats'
 
 definePageMeta({ middleware: ['auth'] })
 
@@ -107,6 +169,7 @@ interface ProgressItem {
 interface Mission {
   id: string
   level: number
+  orderIndex: number
   title: string
 }
 
@@ -124,11 +187,16 @@ const { data: missionsByLevel } = await useFetch<Record<string, Mission[]>>(
 
 const progressList = computed(() => progressRaw.value ?? [])
 
-// 全ミッション数
 const allMissions = computed(() => {
   if (!missionsByLevel.value) return []
   return Object.values(missionsByLevel.value).flat()
 })
+
+// ゲーミフィケーション統計
+const game = useGameStats(
+  () => progressList.value,
+  () => allMissions.value,
+)
 
 const completedCount = computed(() => progressList.value.filter((p) => p.status === 'COMPLETED').length)
 const inProgressCount = computed(() => progressList.value.filter((p) => p.status === 'IN_PROGRESS').length)

--- a/frontend/pages/missions/[id]/index.vue
+++ b/frontend/pages/missions/[id]/index.vue
@@ -9,7 +9,10 @@
         <div class="text-center px-8">
           <div class="text-6xl mb-4 animate-bounce">🎉</div>
           <h2 class="text-3xl font-bold text-green-400 mb-2">ミッション完了！</h2>
-          <p class="text-gray-300 mb-8">{{ mission?.title }}</p>
+          <p class="text-gray-300 mb-3">{{ mission?.title }}</p>
+          <p v-if="mission" class="inline-block text-sm font-bold text-yellow-400 bg-yellow-400/10 px-4 py-1.5 rounded-full mb-8">
+            +{{ xpForLevel(mission.level) }} XP 獲得！
+          </p>
           <div class="flex flex-col sm:flex-row gap-3 justify-center">
             <NuxtLink
               to="/missions"
@@ -148,6 +151,7 @@
 
 <script setup lang="ts">
 import { useAuthStore } from '~/stores/auth'
+import { xpForLevel } from '~/composables/useGameStats'
 import type { GraphData } from '~/types/terminal'
 
 definePageMeta({ middleware: ['auth'] })


### PR DESCRIPTION
## 概要
学習を続けたくなる仕組みを追加。すべて既存 API のデータからクライアント側で導出（DB 変更なし）。

## 変更内容
- XP: ミッションレベル × 100、累計で 5 段階ランク (みならい冒険者 → Git マスター)
- 実績バッジ 7 種 (はじめの一歩・レベル制覇・コンフリクトバスター・全制覇など)
- 連続学習日数 (ストリーク)
- ダッシュボード刷新 + 完了オーバーレイに獲得 XP 表示

Closes #29

🤖 Generated with [Claude Code](https://claude.com/claude-code)